### PR TITLE
bug! need more judgement when install wireguard first!!

### DIFF
--- a/src/etc/init.d/udptools
+++ b/src/etc/init.d/udptools
@@ -20,7 +20,7 @@ run_udp()
 	config_get timeout $1 timeout
 	(udpspeeder -c -l$client:$clientport -r127.0.0.1:21333 -f$fec --mode 0 --timeout $timeout  >/dev/null 2>&1 )&
 	(udp2raw -c -l127.0.0.1:21333 -r$server:$serverport --raw-mode faketcp -a -k $password >/dev/null 2>&1 )&
-	ip route add $server via $(ip route | awk '$1=="default" {print $3}')
+	ip route add $server via $(ip route | awk '$1=="default" {print $3}') #need do more judge after install wireguard
 }
 
 start()


### PR DESCRIPTION
Bug! because no issue label like other project in github,  I report bug here!

When install wireguard and running, my route table become this:
root@OpenWrt:/usr/bin# ip route
default dev wg0 proto static scope link //added by wireguard
10.162.106.0/24 dev wg0 proto kernel scope link src 10.162.106.10 
45.62.xx.xx via 192.168.1.1 dev eth0.2 proto static  //modified by wireguard
172.16.0.0/16 dev br-lan proto kernel scope link src 172.16.0.1 
192.168.1.0/24 dev eth0.2 proto kernel scope link src 192.168.1.180 

stopped wireguard:
root@OpenWrt:/usr/bin# ip route
45.62.xx.xx via 192.168.1.1 dev eth0.2 proto static 
172.16.0.0/16 dev br-lan proto kernel scope link src 172.16.0.1 
192.168.1.0/24 dev eth0.2 proto kernel scope link src 192.168.1.180 


so line 
ip route add $server via $(ip route | awk '$1=="default" {print $3}')
need do more judge after install wireguard. otherwise ip command error. ip route command need an ip ,not wg0 interface name in this situation as in this example.